### PR TITLE
Fix bram testbench

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
     - litex-hub::prjxray-tools=0.1_2842_g6867429c=20210301_104249
     - litex-hub::prjxray-db=0.0_248_g2e51ad3=20210312_125539
     - litex-hub::yosys=0.9_5357_ga58571d0=20210413_171008_py37
-    - litex-hub::nextpnr-fpga_interchange=v0.0_3395_g1631cdff=20210415_092356
+    - litex-hub::nextpnr-fpga_interchange=v0.0_3405_gb7bf7c11=20210415_092356
     - litex-hub::iverilog=s20150603_0957_gad862020=20201120_145821
     - swig
     - pip

--- a/tests/ram/ram_tb.v
+++ b/tests/ram/ram_tb.v
@@ -74,9 +74,15 @@ always @(posedge clk) begin
 
     if (sw == 16'd9 || rst) begin
         sw <= 0;
-        check_counter <= 4'd13;
     end else begin
         sw <= sw + 1;
+    end
+
+    if (rst) begin
+        check_counter <= 4'd13;
+    end else if (check_counter == 4'd9) begin
+        check_counter <= 4'd0;
+    end else begin
         check_counter <= check_counter + 1;
     end
 


### PR DESCRIPTION
Fix the RAMB testbench which was not correctly checking all the INIT configs due to an out of sync check_counter.