### PR TITLE
kokoro: fix missing license headers

### DIFF
--- a/.github/kokoro/steps/git.sh
+++ b/.github/kokoro/steps/git.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+# Copyright (C) 2021  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
 
 set -e
 

--- a/.github/kokoro/steps/hostinfo.sh
+++ b/.github/kokoro/steps/hostinfo.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+# Copyright (C) 2021  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
 
 set -e
 

--- a/.github/kokoro/steps/hostsetup.sh
+++ b/.github/kokoro/steps/hostsetup.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+# Copyright (C) 2021  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
 
 set -e
 

--- a/.github/kokoro/test.sh
+++ b/.github/kokoro/test.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+# Copyright (C) 2021  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
 
 set -e
 


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

Fixes https://github.com/SymbiFlow/fpga-interchange-tests/issues/10