### PR TITLE
tests: features: add IOBUF basic test

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
     - litex-hub::prjxray-tools=0.1_2842_g6867429c=20210301_104249
     - litex-hub::prjxray-db=0.0_248_g2e51ad3=20210312_125539
     - litex-hub::yosys=0.9_5457_gc6681508=20210615_141355_py38
-    - litex-hub::nextpnr-fpga_interchange=v0.0_3597_gf4bfc2af=20210615_141355
+    - litex-hub::nextpnr-fpga_interchange=v0.0_3610_gc73d4cf6=20210615_141355
     - litex-hub::iverilog=s20150603_0957_gad862020=20201120_145821
     - swig
     - pip

--- a/tests/features/CMakeLists.txt
+++ b/tests/features/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(iobuf)
 add_subdirectory(lut)
 add_subdirectory(pll)
 add_subdirectory(ram)

--- a/tests/features/iobuf/CMakeLists.txt
+++ b/tests/features/iobuf/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_generic_test(
+    name iobuf
+    board_list basys3
+    sources iobuf.v
+    testbench iobuf_tb.v
+)

--- a/tests/features/iobuf/basys3.xdc
+++ b/tests/features/iobuf/basys3.xdc
@@ -1,0 +1,13 @@
+set_property PACKAGE_PIN V17 [get_ports sw[0]]
+set_property PACKAGE_PIN V16 [get_ports sw[1]]
+
+set_property PACKAGE_PIN U16 [get_ports led]
+
+set_property PACKAGE_PIN K17 [get_ports jc1]
+
+set_property IOSTANDARD LVCMOS33 [get_ports sw[0]]
+set_property IOSTANDARD LVCMOS33 [get_ports sw[1]]
+
+set_property IOSTANDARD LVCMOS33 [get_ports led]
+
+set_property IOSTANDARD LVCMOS33 [get_ports jc1]

--- a/tests/features/iobuf/iobuf.v
+++ b/tests/features/iobuf/iobuf.v
@@ -1,0 +1,44 @@
+// Copyright (C) 2021  The Symbiflow Authors.
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier: ISC
+
+// Truth table:
+//
+// SW1 SW0 | LED0
+//  0   0  |  0
+//  0   1  |  1
+//  1   0  |  x
+//  1   1  |  x
+
+module top (
+    output wire led,
+
+    input   wire [1:0] sw,
+    inout   wire jc1
+);
+
+wire io_i;
+wire io_o;
+wire io_t;
+
+IOBUF iobuf
+(
+    .I  (io_i),
+    .T  (io_t),
+    .O  (io_o),
+    .IO (jc1)
+);
+
+// SW0 controls IOBUF.I
+assign io_i = sw[0];
+// SW1 controls IOBUF.T
+assign io_t = sw[1];
+
+// LED0 is connected IOBUF.O
+assign led = io_o;
+
+endmodule

--- a/tests/features/iobuf/iobuf_tb.v
+++ b/tests/features/iobuf/iobuf_tb.v
@@ -1,0 +1,67 @@
+// Copyright (C) 2021  The Symbiflow Authors.
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier: ISC
+
+`timescale 1 ns / 1 ps
+`default_nettype none
+
+module tb;
+
+`include "utils.v"
+
+reg clk;
+reg rst;
+
+reg [2:0] sw;
+
+reg [0:7] check;
+
+always #5 clk <= !clk;
+
+initial begin
+    clk = 1'b0;
+    rst = 1'b1;
+    sw  = 3'b0;
+
+    check = 8'b01000111;
+
+    #10 rst = 1'b0;
+
+    $dumpfile(`STRINGIFY(`VCD));
+    $dumpvars;
+    #100 $finish();
+end
+
+wire led;
+wire jc1;
+
+assign jc1 = sw[1] ? sw[2] : 1'bz;
+
+top dut(
+    .sw(sw[1:0]),
+
+    .led(led),
+    .jc1(jc1)
+);
+
+always @(posedge clk) begin
+    if (rst)
+        sw <= 0;
+    else
+        sw <= sw + 1;
+
+    assert(sw != 3'd0 || led === check[0], led);
+    assert(sw != 3'd1 || led === check[1], led);
+    assert(sw != 3'd2 || led === check[2], led);
+    assert(sw != 3'd3 || led === check[3], led);
+    assert(sw != 3'd4 || led === check[4], led);
+    assert(sw != 3'd5 || led === check[5], led);
+    assert(sw != 3'd6 || led === check[6], led);
+    assert(sw != 3'd7 || led === check[7], led);
+end
+
+endmodule


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

To have a complete round-trip test this requires:

- https://github.com/YosysHQ/nextpnr/pull/733
- Enable correct FASM generation