### PR TITLE
nexus: Add support for generating chipdbs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 env
 build
 src
+capnproto-c++-0.8.0.tar.gz
+capnproto-c++-0.8.0
+capnproto-java

--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "third_party/python-fpga-interchange"]
 	path = third_party/python-fpga-interchange
 	url = https://github.com/SymbiFlow/python-fpga-interchange
+[submodule "third_party/prjoxide"]
+	path = third_party/prjoxide
+	url = https://github.com/gatecat/prjoxide

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ set_program(bitread)
 set_program(bit2fasm)
 set_program(iverilog)
 set_program(vvp)
+set_program(prjoxide)
 
 include(boards/boards.cmake)
 include(devices/chipdb.cmake)

--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,27 @@ build:
 	git submodule update --init --recursive
 	# Update RapidWright jars
 	# TODO: remove patch once https://github.com/Xilinx/RapidWright/issues/183 is solved
+
+	curl -O https://capnproto.org/capnproto-c++-0.8.0.tar.gz
+	tar zxf capnproto-c++-0.8.0.tar.gz
+	pushd capnproto-c++-0.8.0 && \
+		./configure && \
+		$(MAKE) check && \
+		sudo make install && \
+		popd
+
+	git clone https://github.com/capnproto/capnproto-java.git
+	pushd capnproto-java && \
+		$(MAKE) && \
+		sudo make install && \
+		popd
+
 	pushd ${RAPIDWRIGHT_PATH} && \
 		make update_jars && \
 		wget https://github.com/Xilinx/RapidWright/releases/download/v2020.2.5-beta/rapidwright_api_lib-2020.2.5-patch1.zip && \
 		unzip -o rapidwright_api_lib-2020.2.5-patch1.zip && \
 		popd
-	@$(IN_CONDA_ENV) pushd third_party/prjoxide/libprjoxide && \
+	pushd third_party/prjoxide/libprjoxide && \
 		( curl --proto '=https' -sSf https://sh.rustup.rs | sh -s -- -y ) && \
 		source ${HOME}/.cargo/env && \
 		cargo install --path prjoxide --all-features && \

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,13 @@ build:
 		wget https://github.com/Xilinx/RapidWright/releases/download/v2020.2.5-beta/rapidwright_api_lib-2020.2.5-patch1.zip && \
 		unzip -o rapidwright_api_lib-2020.2.5-patch1.zip && \
 		popd
+	@$(IN_CONDA_ENV) pushd third_party/prjoxide/libprjoxide && \
+		( curl --proto '=https' -sSf https://sh.rustup.rs | sh -s -- -y ) && \
+		source ${HOME}/.cargo/env && \
+		cargo install --path prjoxide --all-features && \
+		popd
 	# Build test suite
-	@$(IN_CONDA_ENV) mkdir -p build && cd build && cmake $(CMAKE_FLAGS) ..
+	@$(IN_CONDA_ENV) mkdir -p build && cd build && cmake $(CMAKE_FLAGS) -DPRJOXIDE=${HOME}/.cargo/bin/prjoxide ..
 
 clean-build:
 	rm -rf build

--- a/devices/CMakeLists.txt
+++ b/devices/CMakeLists.txt
@@ -5,3 +5,7 @@ add_subdirectory(xc7a200t)
 
 # Zynq-7 devices
 add_subdirectory(xc7z010)
+
+# Nexus devices
+add_subdirectory(LIFCL-17)
+add_subdirectory(LIFCL-40)

--- a/devices/LIFCL-17/CMakeLists.txt
+++ b/devices/LIFCL-17/CMakeLists.txt
@@ -1,0 +1,13 @@
+generate_nexus_device_db(
+    device LIFCL-17
+    device_target lifcl17_target
+)
+
+generate_chipdb(
+    family ${family}
+    device LIFCL-17
+    part LIFCL-17-7SG72C
+    device_target ${lifcl17_target}
+    device_config ${PYTHON_INTERCHANGE_PATH}/test_data/nexus_device_config.yaml
+    test_package QFN72
+)

--- a/devices/LIFCL-40/CMakeLists.txt
+++ b/devices/LIFCL-40/CMakeLists.txt
@@ -1,0 +1,13 @@
+generate_nexus_device_db(
+    device LIFCL-40
+    device_target lifcl40_target
+)
+
+generate_chipdb(
+    family ${family}
+    device LIFCL-40
+    part LIFCL-40-9BG400C
+    device_target ${lifcl40_target}
+    device_config ${PYTHON_INTERCHANGE_PATH}/test_data/nexus_device_config.yaml
+    test_package CABGA400
+)

--- a/devices/chipdb.cmake
+++ b/devices/chipdb.cmake
@@ -139,6 +139,9 @@ function(patch_device_with_prim_lib)
     set(output_device_file ${CMAKE_CURRENT_BINARY_DIR}/${device}_prim_lib.device)
     set(output_json_file ${CMAKE_CURRENT_BINARY_DIR}/${device}_prim_lib.json)
 
+    get_target_property(PYTHON3 programs PYTHON3)
+    get_target_property(YOSYS programs YOSYS)
+
     add_custom_command(
         OUTPUT ${output_json_file}
         COMMAND

--- a/devices/chipdb_nexus.cmake
+++ b/devices/chipdb_nexus.cmake
@@ -32,6 +32,9 @@ function(create_prjoxide_device_db)
     set(device ${create_prjoxide_device_db_device})
     set(output_target ${create_prjoxide_device_db_output_target})
     set(prjoxide_device_db ${CMAKE_CURRENT_BINARY_DIR}/${device}.device)
+
+    get_target_property(PRJOXIDE programs PRJOXIDE)
+
     add_custom_command(
         OUTPUT ${prjoxide_device_db}
         COMMAND

--- a/devices/chipdb_nexus.cmake
+++ b/devices/chipdb_nexus.cmake
@@ -1,0 +1,101 @@
+function(create_prjoxide_device_db)
+    # ~~~
+    # create_prjoxide_device_db(
+    #    device <common device>
+    #    output_target <output device target>
+    # )
+    # ~~~
+    #
+    # Generates a device database from Project Oxide
+    #
+    # If output_target is specified, the output_target_name variable
+    # is set to the generated output_device_file target.
+    #
+    # Arguments:
+    #   - device: common device name of a set of parts. E.g. LIFCL-17
+    #   - output_target: variable name that will hold the output device target for the parent scope
+    #
+    # Targets generated:
+    #   - prjoxide-<device>-device
+    set(options)
+    set(oneValueArgs device output_target)
+    set(multiValueArgs)
+
+    cmake_parse_arguments(
+        create_prjoxide_device_db
+        "${options}"
+        "${oneValueArgs}"
+        "${multiValueArgs}"
+        ${ARGN}
+    )
+
+    set(device ${create_prjoxide_device_db_device})
+    set(output_target ${create_prjoxide_device_db_output_target})
+    set(prjoxide_device_db ${CMAKE_CURRENT_BINARY_DIR}/${device}.device)
+    add_custom_command(
+        OUTPUT ${prjoxide_device_db}
+        COMMAND
+            ${PRJOXIDE}
+            interchange-export
+            ${device}
+            ${prjoxide_device_db}
+        DEPENDS
+            ${PRJOXIDE}
+    )
+
+    add_custom_target(prjoxide-${device}-device DEPENDS ${prjoxide_device_db})
+    set_property(TARGET prjoxide-${device}-device PROPERTY LOCATION ${prjoxide_device_db})
+
+    if (DEFINED output_target)
+        set(${output_target} prjoxide-${device}-device PARENT_SCOPE)
+    endif()
+
+endfunction()
+
+function(generate_nexus_device_db)
+    # ~~~
+    # generate_nexus_device_db(
+    #    device <common device>
+    #    device_target <variable name for device target>
+    # )
+    # ~~~
+    #
+    # Generates a chipdb BBA file, starting from a Project Oxide device database.
+    # Patches applied:
+    #   - primitive library from Yosys
+    #
+    # Arguments:
+    #   - device: common device name of a set of parts. E.g. LIFCL-17
+    #   - device_target: variable name that will hold the output device target for the parent scope
+    set(options)
+    set(oneValueArgs device device_target)
+    set(multiValueArgs)
+
+    cmake_parse_arguments(
+        generate_nexus_device_db
+        "${options}"
+        "${oneValueArgs}"
+        "${multiValueArgs}"
+        ${ARGN}
+    )
+
+    set(device ${generate_nexus_device_db_device})
+    set(device_target ${generate_nexus_device_db_device_target})
+
+    create_prjoxide_device_db(
+        device ${device}
+        output_target prjoxide_device
+    )
+
+    # Add primitive library
+    patch_device_with_prim_lib(
+        device ${device}
+        yosys_script synth_nexus
+        input_device ${prjoxide_device}
+        output_target prjoxide_prims_device
+    )
+
+    if(DEFINED device_target)
+        set(${device_target} ${prjoxide_prims_device} PARENT_SCOPE)
+    endif()
+endfunction()


### PR DESCRIPTION
I don't think this is going to pass CI, because we aren't installing prjoxide, but I'm not sure what the best way to proceed there is? Either we can try and get a conda package for prjoxide going, or add a rule to build prjoxide manually like we do in the nextpnr CI.

cc @acomodi 