### PR TITLE
tests: xc7: use carry chains

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
     - litex-hub::prjxray-tools=0.1_2842_g6867429c=20210301_104249
     - litex-hub::prjxray-db=0.0_252_g8372b58=20210622_220029
     - litex-hub::yosys=0.9_5457_gc6681508=20210615_141355_py38
-    - litex-hub::nextpnr-fpga_interchange=v0.0_3688_g084e15f9=20210625_074838
+    - litex-hub::nextpnr-fpga_interchange=v0.0_3690_g2c459961=20210625_074838
     - litex-hub::iverilog=s20150603_0957_gad862020=20201120_145821
     - litex-hub::prjoxide=v0.0_376_gd0b0340=20210624_125028
     - swig

--- a/tests/arch_tests.cmake
+++ b/tests/arch_tests.cmake
@@ -151,6 +151,52 @@ function(add_xc7_test)
             ${fasm}
         )
 
+    set(bit_fasm ${output_dir}/${name}.bit.fasm)
+    add_custom_command(
+        OUTPUT ${bit_fasm}
+        COMMAND
+            ${quiet_cmd}
+            ${BIT2FASM}
+                --db-root ${PRJXRAY_DB_DIR}/${device_family}
+                --part ${part}
+                --bitread ${BITREAD}
+                --fasm_file ${bit_fasm}
+                ${bit}
+        DEPENDS
+            ${bit}
+            xc7-${test_name}-bit
+    )
+    add_custom_target(xc7-${test_name}-bit-fasm DEPENDS ${bit_fasm})
+
+    set(dcp_fasm ${output_dir}/${name}.dcp.bit.fasm)
+    add_custom_command(
+        OUTPUT ${dcp_fasm}
+        COMMAND
+            ${quiet_cmd}
+            ${BIT2FASM}
+                --db-root ${PRJXRAY_DB_DIR}/${device_family}
+                --part ${part}
+                --bitread ${BITREAD}
+                --fasm_file ${dcp_fasm}
+                ${dcp_bit}
+        DEPENDS
+            ${dcp_bit}
+            xc7-${test_name}-dcp-bit
+    )
+    add_custom_target(xc7-${test_name}-dcp-bit-fasm DEPENDS ${dcp_fasm})
+
+
+    add_custom_target(xc7-${test_name}-dcp-diff-fasm
+        COMMAND diff -u
+            ${bit_fasm}
+            ${dcp_fasm}
+        DEPENDS
+            xc7-${test_name}-bit-fasm
+            xc7-${test_name}-dcp-bit-fasm
+            ${bit_fasm}
+            ${dcp_fasm}
+    )
+
     add_custom_target(${arch}-${test_name}-bit DEPENDS ${bit})
     add_dependencies(all-tests ${arch}-${test_name}-bit)
     add_dependencies(all-${device}-tests ${arch}-${test_name}-bit)

--- a/tests/arch_tests.cmake
+++ b/tests/arch_tests.cmake
@@ -204,7 +204,6 @@ function(add_xc7_test)
     # generate vivado timing report
     set(vivado_report ${output_dir}/vivado_report.txt)
     set(vivado_timing_tcl ${CMAKE_SOURCE_DIR}/tests/common/timing_dump_vivado.tcl)
-    message(STATUS "${arch} ${test_name} ${board} ${name}")
     add_custom_command(
         OUTPUT ${vivado_report}
         COMMAND ${CMAKE_COMMAND} -E env

--- a/tests/common/synth_xc7.tcl
+++ b/tests/common/synth_xc7.tcl
@@ -4,7 +4,7 @@ foreach src $::env(SOURCES) {
     read_verilog $src
 }
 
-synth_xilinx -flatten -nolutram -nowidelut -nosrl -nocarry -nodsp
+synth_xilinx -flatten -nolutram -nowidelut -nosrl -nodsp
 
 if { $::env(TECHMAP) != "" } {
     techmap -map $::env(TECHMAP)

--- a/tests/designs/murax/basys3_toplevel.v
+++ b/tests/designs/murax/basys3_toplevel.v
@@ -16,14 +16,6 @@ module toplevel(
     output [15:0] io_led
   );
 
-  // Divide clock by 2
-  reg clk50 = 1'b0;
-  always @(posedge io_mainClk)
-      clk50 <= !clk50;
-
-  wire clk50_bufg;
-  BUFG bufg50 (.I(clk50), .O(clk50_bufg));
-
   wire [31:0] io_gpioA_read;
   wire [31:0] io_gpioA_write;
   wire [31:0] io_gpioA_writeEnable;
@@ -40,7 +32,7 @@ module toplevel(
 
   Murax murax (
     .io_asyncReset(0),
-    .io_mainClk (clk50_bufg ),
+    .io_mainClk (io_mainClk ),
     .io_jtag_tck(1'b0),
     .io_jtag_tdi(1'b0),
     .io_jtag_tms(1'b0),


### PR DESCRIPTION
This PR enables carry chains for XC7 devices.

It is currently marked as WIP as there are issues with the FASM generation where some features corresponding to the carry chains are not correctly emitted