### PR TITLE
Add timing tests

### DIFF
--- a/.github/kokoro/test.sh
+++ b/.github/kokoro/test.sh
@@ -35,7 +35,7 @@ echo "-------------------------------------------"
     make all-tests -j$NUM_CORES
     make all-validation-tests -j$NUM_CORES
     make all-vendor-bit-tests -j$NUM_CORES
-    make xilinx-timing-tests -j$NUM_CORES
+    make all-timing-comparasion-tests -j$NUM_CORES
     popd
 )
 echo "-------------------------------------------"

--- a/.github/kokoro/test.sh
+++ b/.github/kokoro/test.sh
@@ -35,6 +35,7 @@ echo "-------------------------------------------"
     make all-tests -j$NUM_CORES
     make all-validation-tests -j$NUM_CORES
     make all-vendor-bit-tests -j$NUM_CORES
+    make xilinx-timing-tests -j$NUM_CORES
     popd
 )
 echo "-------------------------------------------"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,14 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install git make cmake
+        git submodule status > .submodules_status
 
     - name: Cache environment
       id: cache-env
       uses: actions/cache@v2
       with:
         path: env
-        key: env-${{ hashFiles('**/environment.yml', '**/requirements.txt', '**/third_party_versions.txt') }}
+        key: env-${{ hashFiles('**/environment.yml', '**/requirements.txt', '**/.submodules_status') }}
 
     - name: Create environment
       if: steps.cache-env.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: env
-        key: env-${{ hashFiles('**/environment.yml', '**/requirements.txt') }}
+        key: env-${{ hashFiles('**/environment.yml', '**/requirements.txt', '**/third_party') }}
 
     - name: Create environment
       if: steps.cache-env.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: env
-        key: env-${{ hashFiles('**/environment.yml', '**/requirements.txt', '**/third_party') }}
+        key: env-${{ hashFiles('**/environment.yml', '**/requirements.txt', '**/third_party_versions.txt') }}
 
     - name: Create environment
       if: steps.cache-env.outputs.cache-hit != 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ include(tests/arch_tests.cmake)
 include(tests/tests.cmake)
 
 add_custom_target(all-tests)
+add_custom_target(xilinx-timing-tests)
 add_custom_target(all-validation-tests)
 add_custom_target(all-vendor-bit-tests)
 add_custom_target(all-simulation-tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ include(tests/arch_tests.cmake)
 include(tests/tests.cmake)
 
 add_custom_target(all-tests)
-add_custom_target(xilinx-timing-tests)
+add_custom_target(all-timing-comparasion-tests)
 add_custom_target(all-validation-tests)
 add_custom_target(all-vendor-bit-tests)
 add_custom_target(all-simulation-tests)

--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,8 @@ update:
 		make update_jars && \
 		popd
 
-.PHONY:
-third_party_SHA:
-	git submodule status > third_party_versions.txt
-
 .PHONY: build
-build: update third_party_SHA
+build: update
 	# Build test suite
 	@$(IN_CONDA_ENV) mkdir -p build && cd build && cmake ${CMAKE_FLAGS} ..
 

--- a/Makefile
+++ b/Makefile
@@ -28,15 +28,15 @@ update:
 		make update_jars && \
 		popd
 
+.PHONY:
+third_party_SHA:
+	git submodule status > third_party_versions.txt
+
 .PHONY: build
-build: update
+build: update third_party_SHA
 	# Build test suite
 	@$(IN_CONDA_ENV) mkdir -p build && cd build && cmake ${CMAKE_FLAGS} ..
 
 .PHONY: clean-build
 clean-build:
 	rm -rf build/*
-
-.PHONY:
-third_party_SHA:
-	git submodule status > third_party_versions.txt

--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,7 @@ build: update
 .PHONY: clean-build
 clean-build:
 	rm -rf build/*
+
+.PHONY:
+third_party_SHA:
+	git submodule status > third_party_versions.txt

--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,16 @@ third_party/make-env/conda.mk:
 
 include third_party/make-env/conda.mk
 
-.PHONY: build
-build:
+.PHONY: update
+update:
 	git submodule init
 	git submodule update --init --recursive
 	pushd ${RAPIDWRIGHT_PATH} && \
 		make update_jars && \
 		popd
+
+.PHONY: build
+build: update
 	# Build test suite
 	@$(IN_CONDA_ENV) mkdir -p build && cd build && cmake ${CMAKE_FLAGS} ..
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ third_party/make-env/conda.mk:
 
 include third_party/make-env/conda.mk
 
+.PHONY: build
 build:
 	git submodule init
 	git submodule update --init --recursive
@@ -29,5 +30,6 @@ build:
 	# Build test suite
 	@$(IN_CONDA_ENV) mkdir -p build && cd build && cmake ${CMAKE_FLAGS} ..
 
+.PHONY: clean-build
 clean-build:
-	rm -rf build
+	rm -rf build/*

--- a/devices/chipdb.cmake
+++ b/devices/chipdb.cmake
@@ -280,6 +280,7 @@ function(generate_chipdb)
     )
 
     add_custom_target(all-${device}-tests)
+    add_custom_target(all-${device}-timing-comparasion-tests)
     add_custom_target(all-${device}-validation-tests)
     add_custom_target(all-${device}-vendor-bit-tests)
     add_custom_target(all-${device}-simulation-tests)

--- a/devices/chipdb_xilinx.cmake
+++ b/devices/chipdb_xilinx.cmake
@@ -95,17 +95,17 @@ function(generate_xc7_device_db)
     set(multiValueArgs)
 
     cmake_parse_arguments(
-        create_rapidwright_device_db
+        generate_xc7_device_db
         "${options}"
         "${oneValueArgs}"
         "${multiValueArgs}"
         ${ARGN}
     )
 
-    set(device ${create_rapidwright_device_db_device})
-    set(part ${create_rapidwright_device_db_part})
-    set(device_target ${create_rapidwright_device_db_device_target})
-    set(family ${create_rapidwright_device_db_family})
+    set(device ${generate_xc7_device_db_device})
+    set(part ${generate_xc7_device_db_part})
+    set(device_target ${generate_xc7_device_db_device_target})
+    set(family ${generate_xc7_device_db_family})
 
     create_rapidwright_device_db(
         device ${device}
@@ -134,7 +134,7 @@ function(generate_xc7_device_db)
         patch_data ${PYTHON_INTERCHANGE_PATH}/test_data/series7_luts.yaml
         input_device ${constraints_device}
         output_target constraints_luts_device
-        output_name ${device}
+        output_name ${device}_constraints_luts
     )
 
     get_target_property(input_device_loc ${constraints_luts_device} LOCATION)

--- a/devices/chipdb_xilinx.cmake
+++ b/devices/chipdb_xilinx.cmake
@@ -209,3 +209,63 @@ function(generate_xcup_device_db)
         set(${device_target} ${constraints_luts_device} PARENT_SCOPE)
     endif()
 endfunction()
+
+function(generate_xc7_device_with_timings)
+    # ~~~
+    # generate_xc7_device_with_timings(
+    #    device <common device>
+    #    input_device <input device>
+    #    output_device <variable name for device target>
+    #    family <xilinx family>
+    # )
+    # ~~~
+    #
+    # Generates capnp device with timing patches applied.
+    #
+    # Arguments:
+    #   - device: common device name of a set of parts. E.g. xc7a35tcsg324-1 and xc7a35tcpg236-1
+    #             share the same xc7a35t device prefix
+    #   - input_device: name of the file that contains device for patching
+    #   - output_device: variable name that will hold the output device target for the parent scope
+    #   - family: xilinx family name for device eg.: artix7, zynq7
+
+    set(options)
+    set(oneValueArgs device input_device output_device family)
+    set(multiValueArgs)
+
+    cmake_parse_arguments(
+        create_xc7_device_with_timings
+        "${options}"
+        "${oneValueArgs}"
+        "${multiValueArgs}"
+        ${ARGN}
+    )
+
+    set(device ${create_xc7_device_with_timings_device})
+    set(input_device ${create_xc7_device_with_timings_input_device})
+    set(output_device ${create_xc7_device_with_timings_output_device})
+    set(family ${create_xc7_device_with_timings_family})
+
+    get_target_property(input_device_loc ${input_device} LOCATION)
+    set(patched_device ${CMAKE_CURRENT_BINARY_DIR}/${device}_timing.device)
+    add_custom_command(
+        OUTPUT ${patched_device}
+        COMMAND
+            ${PYTHON3} -mfpga_interchange.device_timing_patching
+                --family xc7
+                --schema_dir ${INTERCHANGE_SCHEMA_PATH}
+                --timing_dir ${PRJXRAY_DB_DIR}/${family}
+                ${input_device_loc}
+                ${patched_device}
+        DEPENDS
+            ${input_device}
+            ${input_device_loc}
+    )
+
+    add_custom_target(timing-${device}-device DEPENDS ${patched_device})
+    set_property(TARGET timing-${device}-device PROPERTY LOCATION ${patched_device})
+
+    if(DEFINED device_target)
+        set(${output_device} timing-${device}-device PARENT_SCOPE)
+    endif()
+endfunction()

--- a/devices/xc7a100t/CMakeLists.txt
+++ b/devices/xc7a100t/CMakeLists.txt
@@ -12,3 +12,10 @@ generate_chipdb(
     device_config ${PYTHON_INTERCHANGE_PATH}/test_data/series7_device_config.yaml
     test_package csg324
 )
+
+generate_xc7_device_with_timings(
+    device xc7a100t
+    input_device ${xc7a100t_target}
+    output_device xc7a100t_timing_target
+    family artix7
+)

--- a/devices/xc7a100t/CMakeLists.txt
+++ b/devices/xc7a100t/CMakeLists.txt
@@ -2,6 +2,7 @@ generate_xc7_device_db(
     device xc7a100t
     part xc7a100tcsg324-1
     device_target xc7a100t_target
+    family artix7
 )
 
 generate_chipdb(
@@ -11,11 +12,4 @@ generate_chipdb(
     device_target ${xc7a100t_target}
     device_config ${PYTHON_INTERCHANGE_PATH}/test_data/series7_device_config.yaml
     test_package csg324
-)
-
-generate_xc7_device_with_timings(
-    device xc7a100t
-    input_device ${xc7a100t_target}
-    output_device xc7a100t_timing_target
-    family artix7
 )

--- a/devices/xc7a200t/CMakeLists.txt
+++ b/devices/xc7a200t/CMakeLists.txt
@@ -12,3 +12,10 @@ generate_chipdb(
     device_config ${PYTHON_INTERCHANGE_PATH}/test_data/series7_device_config.yaml
     test_package sbg484
 )
+
+generate_xc7_device_with_timings(
+    device xc7a200t
+    input_device ${xc7a200t_target}
+    output_device xc7a200t_timing_target
+    family artix7
+)

--- a/devices/xc7a200t/CMakeLists.txt
+++ b/devices/xc7a200t/CMakeLists.txt
@@ -2,6 +2,7 @@ generate_xc7_device_db(
     device xc7a200t
     part xc7a200tsbg484-1
     device_target xc7a200t_target
+    family artix7
 )
 
 generate_chipdb(
@@ -11,11 +12,4 @@ generate_chipdb(
     device_target ${xc7a200t_target}
     device_config ${PYTHON_INTERCHANGE_PATH}/test_data/series7_device_config.yaml
     test_package sbg484
-)
-
-generate_xc7_device_with_timings(
-    device xc7a200t
-    input_device ${xc7a200t_target}
-    output_device xc7a200t_timing_target
-    family artix7
 )

--- a/devices/xc7a35t/CMakeLists.txt
+++ b/devices/xc7a35t/CMakeLists.txt
@@ -2,6 +2,7 @@ generate_xc7_device_db(
     device xc7a35t
     part xc7a35tcsg324-1
     device_target xc7a35t_target
+    family artix7
 )
 
 generate_chipdb(
@@ -10,11 +11,4 @@ generate_chipdb(
     device_target ${xc7a35t_target}
     device_config ${PYTHON_INTERCHANGE_PATH}/test_data/series7_device_config.yaml
     test_package csg324
-)
-
-generate_xc7_device_with_timings(
-    device xc7a35t
-    input_device ${xc7a35t_target}
-    output_device xc7a35t_timing_target
-    family artix7
 )

--- a/devices/xc7a35t/CMakeLists.txt
+++ b/devices/xc7a35t/CMakeLists.txt
@@ -11,3 +11,10 @@ generate_chipdb(
     device_config ${PYTHON_INTERCHANGE_PATH}/test_data/series7_device_config.yaml
     test_package csg324
 )
+
+generate_xc7_device_with_timings(
+    device xc7a35t
+    input_device ${xc7a35t_target}
+    output_device xc7a35t_timing_target
+    family artix7
+)

--- a/devices/xc7z010/CMakeLists.txt
+++ b/devices/xc7z010/CMakeLists.txt
@@ -12,3 +12,10 @@ generate_chipdb(
     device_config ${PYTHON_INTERCHANGE_PATH}/test_data/series7_device_config.yaml
     test_package clg400
 )
+
+generate_xc7_device_with_timings(
+    device xc7z010
+    input_device ${xc7z010_target}
+    output_device xc7z010_timing_target
+    family zynq7
+)

--- a/devices/xc7z010/CMakeLists.txt
+++ b/devices/xc7z010/CMakeLists.txt
@@ -2,6 +2,7 @@ generate_xc7_device_db(
     device xc7z010
     part xc7z010clg400-1
     device_target xc7z010_target
+    family zynq7
 )
 
 generate_chipdb(
@@ -11,11 +12,4 @@ generate_chipdb(
     device_target ${xc7z010_target}
     device_config ${PYTHON_INTERCHANGE_PATH}/test_data/series7_device_config.yaml
     test_package clg400
-)
-
-generate_xc7_device_with_timings(
-    device xc7z010
-    input_device ${xc7z010_target}
-    output_device xc7z010_timing_target
-    family zynq7
 )

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
     - litex-hub::prjxray-tools=0.1_2842_g6867429c=20210301_104249
     - litex-hub::prjxray-db=0.0_252_g8372b58=20210622_220029
     - litex-hub::yosys=0.9_5457_gc6681508=20210615_141355_py38
-    - litex-hub::nextpnr-fpga_interchange=v0.0_3686_g034467ff=20210625_074838
+    - litex-hub::nextpnr-fpga_interchange=v0.0_3688_g084e15f9=20210625_074838
     - litex-hub::iverilog=s20150603_0957_gad862020=20201120_145821
     - litex-hub::prjoxide=v0.0_376_gd0b0340=20210624_125028
     - swig

--- a/tests/arch_tests.cmake
+++ b/tests/arch_tests.cmake
@@ -178,8 +178,11 @@ function(add_xc7_test)
     add_custom_command(
         OUTPUT ${custom_report}
         COMMAND ${CMAKE_COMMAND} -E env
-            python3 -m fpga_interchange.static_timing_analysis --schema_dir ${INTERCHANGE_SCHEMA_PATH} --device ${device_db}
-            --physical_netlist ${phys} --compact > ${custom_report}
+            ${PYTHON3} -m fpga_interchange.static_timing_analysis
+            --schema_dir ${INTERCHANGE_SCHEMA_PATH}
+            --device ${device_db}
+            --physical_netlist ${phys}
+            --compact > ${custom_report}
         DEPENDS
             ${arch}-${test_name}-phys
             timing-${device}-device
@@ -192,7 +195,7 @@ function(add_xc7_test)
     add_custom_command(
         OUTPUT ${compare_report}
         COMMAND
-            python3 -m fpga_interchange.compare_timings
+            ${PYTHON3} -m fpga_interchange.compare_timings
             --base_timing ${vivado_report}
             --compare_timing ${custom_report}
             --output_file ${compare_report}

--- a/tests/arch_tests.cmake
+++ b/tests/arch_tests.cmake
@@ -174,13 +174,13 @@ function(add_xc7_test)
     # generate custom timing report
     set(custom_report ${output_dir}/custom_report.txt)
     set(phys ${output_dir}/${name}.phys)
-    set(device_db ${CMAKE_BINARY_DIR}/devices/${device}/${device}_timing.device)
+    get_target_property(timing_target_loc timing-${device}-device LOCATION)
     add_custom_command(
         OUTPUT ${custom_report}
         COMMAND ${CMAKE_COMMAND} -E env
             ${PYTHON3} -m fpga_interchange.static_timing_analysis
             --schema_dir ${INTERCHANGE_SCHEMA_PATH}
-            --device ${device_db}
+            --device ${timing_target_loc}
             --physical_netlist ${phys}
             --compact > ${custom_report}
         DEPENDS

--- a/tests/arch_tests.cmake
+++ b/tests/arch_tests.cmake
@@ -203,7 +203,7 @@ function(add_xc7_test)
 
     add_custom_target(${arch}-${test_name}-compare-timings DEPENDS ${compare_report})
     add_dependencies(all-timing-comparasion-tests ${arch}-${test_name}-compare-timings)
-    add_dependencies(all-${device}-tests ${arch}-${test_name}-compare-timings)
+    add_dependencies(all-${device}-timing-comparasion-tests ${arch}-${test_name}-compare-timings)
 endfunction()
 
 function(add_xcup_test)

--- a/tests/arch_tests.cmake
+++ b/tests/arch_tests.cmake
@@ -520,6 +520,92 @@ function(add_xc7_validation_test)
     endforeach()
 endfunction()
 
+function(add_xc7_timing_test)
+    # ~~~
+    # add_xc7_timing_test(
+    #    name <name>
+    #    device <device>
+    #    board <board>
+    # )
+    #
+    # Patches xc7 devices with timing data from prjxray-db
+    #
+    # Arguments:
+    #   - name: test name
+    #
+    # Targets generated:
+    #   - vivado_report.txt    : vivado timing report
+    #   - custom_report.txt    : python fpga interchange STA timing report
+    #   - compare_report.txt   : compare report between vivado and python fpga interchange STA values
+
+    set(options)
+    set(oneValueArgs name device board)
+    set(multiValueArgs)
+
+    cmake_parse_arguments(
+        add_xc7_timing_test
+        "${options}"
+        "${oneValueArgs}"
+        "${multiValueArgs}"
+        ${ARGN}
+    )
+
+    set(device ${add_xc7_timing_test_device})
+    set(name ${add_xc7_timing_test_name})
+    set(board ${add_xc7_timing_test_board})
+
+    set(quiet_cmd ${CMAKE_SOURCE_DIR}/utils/quiet_cmd.sh)
+    set(test_name "${name}-${board}")
+    set(dcp ${output_dir}/${name}.dcp)
+    set(run_vivado ${CMAKE_SOURCE_DIR}/utils/run_vivado.sh)
+    set(vivado_report ${output_dir}/vivado_report.txt)
+    set(vivado_timing_tcl ${CMAKE_SOURCE_DIR}/tests/common/timing_dump_vivado.tcl)
+    message(STATUS "${arch} ${test_name} ${board} ${name}")
+    add_custom_command(
+        OUTPUT ${vivado_report}
+        COMMAND ${CMAKE_COMMAND} -E env
+            VIVADO_SETTINGS=${VIVADO_SETTINGS}
+            ${quiet_cmd}
+            ${run_vivado} -mode tcl -source ${vivado_timing_tcl} -tclargs ${dcp} ${vivado_report}
+        DEPENDS
+            ${dcp}
+    )
+
+    add_custom_target(${arch}-${test_name}-vivado-report DEPENDS ${vivado_report})
+
+    set(custom_report ${output_dir}/custom_report.txt)
+    set(phys ${output_dir}/${name}.phys)
+    set(device_db ${CMAKE_BINARY_DIR}/devices/${device}/${device}_timing.device)
+    add_custom_command(
+        OUTPUT ${custom_report}
+        COMMAND ${CMAKE_COMMAND} -E env
+            python3 -m fpga_interchange.static_timing_analysis --schema_dir ${INTERCHANGE_SCHEMA_PATH} --device ${device_db}
+            --physical_netlist ${phys} --compact > ${custom_report}
+        DEPENDS
+            ${arch}-${test_name}-phys
+            timing-${device}-device
+    )
+
+    add_custom_target(${arch}-${test_name}-custom-report DEPENDS ${custom_report})
+
+    set(compare_report ${output_dir}/compare_report.txt)
+    add_custom_command(
+        OUTPUT ${compare_report}
+        COMMAND
+            python3 -m fpga_interchange.compare_timings
+            --base_timing ${vivado_report}
+            --compare_timing ${custom_report}
+            --output_file ${compare_report}
+        DEPENDS
+            ${arch}-${test_name}-vivado-report
+            ${arch}-${test_name}-custom-report
+    )
+
+    add_custom_target(${arch}-${test_name}-compare-timings DEPENDS ${compare_report})
+    add_dependencies(xilinx-timing-tests ${arch}-${test_name}-compare-timings)
+
+endfunction()
+
 function(add_nexus_test)
     # ~~~
     # add_nexus_test(

--- a/tests/common/timing_dump_vivado.tcl
+++ b/tests/common/timing_dump_vivado.tcl
@@ -3,8 +3,8 @@ read_checkpoint [lindex $argv 0]
 link_design
 foreach net [get_nets] {
 	if {[get_nets $net] != ""} {
-		if {[get_net_delays -of_objects [get_nets $net]] != ""} {
-			puts $fp "$net [get_property SLOW_MAX [lindex [get_net_delays -of_objects [get_nets $net]] 0]]"
+		foreach delay [get_net_delays -interconnect_only -of_objects [get_nets $net]] {
+			puts $fp "[get_property name $delay] [get_property SLOW_MAX $delay]"
 		}
 	}
 }

--- a/tests/common/timing_dump_vivado.tcl
+++ b/tests/common/timing_dump_vivado.tcl
@@ -1,0 +1,12 @@
+set fp [open [lindex $argv 1] w]
+read_checkpoint [lindex $argv 0]
+link_design
+foreach net [get_nets] {
+	if {[get_nets $net] != ""} {
+		if {[get_net_delays -of_objects [get_nets $net]] != ""} {
+			puts $fp "$net [get_property SLOW_MAX [lindex [get_net_delays -of_objects [get_nets $net]] 0]]"
+		}
+	}
+}
+close $fp
+exit

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -266,6 +266,11 @@ function(add_generic_test)
                 fasm ${fasm}
                 top ${top}
             )
+            add_xc7_timing_test(
+                name ${name}
+                device ${device}
+                board ${board}
+            )
         elseif(${arch} STREQUAL "xcup")
             add_xcup_test(
                 name ${name}

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -266,11 +266,6 @@ function(add_generic_test)
                 fasm ${fasm}
                 top ${top}
             )
-            add_xc7_timing_test(
-                name ${name}
-                device ${device}
-                board ${board}
-            )
         elseif(${arch} STREQUAL "xcup")
             add_xcup_test(
                 name ${name}

--- a/third_party_versions.txt
+++ b/third_party_versions.txt
@@ -1,5 +1,5 @@
  b106c3ab421fe7b9b5986c42a234b3fba2190e3b third_party/RapidWright (v2020.2.6-beta-2-gb106c3a)
- e1b906fb15873c65f88c4793714f726c23d736e8 third_party/fpga-interchange-schema (v0.0-75-ge1b906f)
++78abf3f30770ccc6d0e1f5dbfeaef2666f55acf6 third_party/fpga-interchange-schema (v0.0-75-g78abf3f)
  9b07ad2bb62fbf8af789c9e4669715c974b4912d third_party/make-env (v0.0-51-g9b07ad2)
- fd777df3b5763f17d0554ae45c903ca3317ee065 third_party/python-fpga-interchange (v0.0.16-17-gfd777df)
++ddad49dc5c0a0acd151fdf9600031f124089f1a2 third_party/python-fpga-interchange (v0.0.16-21-gddad49d)
  1c8e05fd1e9a79ceb8b996a0996674122eed086f third_party/xilinx-unisims (heads/master)

--- a/third_party_versions.txt
+++ b/third_party_versions.txt
@@ -1,0 +1,5 @@
+ b106c3ab421fe7b9b5986c42a234b3fba2190e3b third_party/RapidWright (v2020.2.6-beta-2-gb106c3a)
+ e1b906fb15873c65f88c4793714f726c23d736e8 third_party/fpga-interchange-schema (v0.0-75-ge1b906f)
+ 9b07ad2bb62fbf8af789c9e4669715c974b4912d third_party/make-env (v0.0-51-g9b07ad2)
+ fd777df3b5763f17d0554ae45c903ca3317ee065 third_party/python-fpga-interchange (v0.0.16-17-gfd777df)
+ 1c8e05fd1e9a79ceb8b996a0996674122eed086f third_party/xilinx-unisims (heads/master)

--- a/third_party_versions.txt
+++ b/third_party_versions.txt
@@ -1,5 +1,5 @@
  b106c3ab421fe7b9b5986c42a234b3fba2190e3b third_party/RapidWright (v2020.2.6-beta-2-gb106c3a)
  78abf3f30770ccc6d0e1f5dbfeaef2666f55acf6 third_party/fpga-interchange-schema (v0.0-75-g78abf3f)
  9b07ad2bb62fbf8af789c9e4669715c974b4912d third_party/make-env (v0.0-51-g9b07ad2)
- ddad49dc5c0a0acd151fdf9600031f124089f1a2 third_party/python-fpga-interchange (v0.0.16-21-gddad49d)
+ f657267ae8ab632066ba64dd40da3867b77e3ae9 third_party/python-fpga-interchange (v0.0.17)
  1c8e05fd1e9a79ceb8b996a0996674122eed086f third_party/xilinx-unisims (heads/master)

--- a/third_party_versions.txt
+++ b/third_party_versions.txt
@@ -1,5 +1,5 @@
  b106c3ab421fe7b9b5986c42a234b3fba2190e3b third_party/RapidWright (v2020.2.6-beta-2-gb106c3a)
-+78abf3f30770ccc6d0e1f5dbfeaef2666f55acf6 third_party/fpga-interchange-schema (v0.0-75-g78abf3f)
+ 78abf3f30770ccc6d0e1f5dbfeaef2666f55acf6 third_party/fpga-interchange-schema (v0.0-75-g78abf3f)
  9b07ad2bb62fbf8af789c9e4669715c974b4912d third_party/make-env (v0.0-51-g9b07ad2)
-+ddad49dc5c0a0acd151fdf9600031f124089f1a2 third_party/python-fpga-interchange (v0.0.16-21-gddad49d)
+ ddad49dc5c0a0acd151fdf9600031f124089f1a2 third_party/python-fpga-interchange (v0.0.16-21-gddad49d)
  1c8e05fd1e9a79ceb8b996a0996674122eed086f third_party/xilinx-unisims (heads/master)

--- a/third_party_versions.txt
+++ b/third_party_versions.txt
@@ -1,5 +1,0 @@
- b106c3ab421fe7b9b5986c42a234b3fba2190e3b third_party/RapidWright (v2020.2.6-beta-2-gb106c3a)
- 78abf3f30770ccc6d0e1f5dbfeaef2666f55acf6 third_party/fpga-interchange-schema (v0.0-75-g78abf3f)
- 9b07ad2bb62fbf8af789c9e4669715c974b4912d third_party/make-env (v0.0-51-g9b07ad2)
- f657267ae8ab632066ba64dd40da3867b77e3ae9 third_party/python-fpga-interchange (v0.0.17)
- 1c8e05fd1e9a79ceb8b996a0996674122eed086f third_party/xilinx-unisims (heads/master)


### PR DESCRIPTION
This pull request is initial support for timing testing.
Right now we only compare timing results for nextpnr routing.

Signed-off-by: Maciej Dudek <mdudek@antmicro.com>