### PR TITLE
xcup: Enable global clock routing

### DIFF
--- a/tests/common/dcp_vivado.tcl
+++ b/tests/common/dcp_vivado.tcl
@@ -19,7 +19,10 @@ set_property IS_ENABLED 0 [get_drc_checks {NSTD-1}]
 # Reports
 report_utilization -file $::env(OUTPUT_DIR)/utilization.rpt
 report_clock_utilization -file $::env(OUTPUT_DIR)/clock_utilization.rpt
-report_timing_summary -datasheet -max_paths 10 -file $::env(OUTPUT_DIR)/timing_summary.rpt
+if { $::env(ARCH) != "xcup" } {
+	# This segfaults Vivado on the counter-zcu104 example...
+	report_timing_summary -datasheet -max_paths 10 -file $::env(OUTPUT_DIR)/timing_summary.rpt
+}
 report_power -file $::env(OUTPUT_DIR)/power.rpt
 report_route_status -file $::env(OUTPUT_DIR)/route_status.rpt
 

--- a/tests/common/remap_xcup.v
+++ b/tests/common/remap_xcup.v
@@ -17,3 +17,9 @@ module BUF(input I, output O);
 LUT1 #(.INIT(2'b10)) _TECHMAP_REPLACE_ (.I0(I), .O(O));
 
 endmodule
+
+module BUFG(input I, output O);
+
+BUFGCE #(.SIM_DEVICE("ULTRASCALE_PLUS")) _TECHMAP_REPLACE_ (.I(I), .CE(1'b1), .O(O));
+
+endmodule

--- a/tests/common/synth_xcup.tcl
+++ b/tests/common/synth_xcup.tcl
@@ -4,7 +4,7 @@ foreach src $::env(SOURCES) {
     read_verilog $src
 }
 
-synth_xilinx -flatten -noclkbuf -nolutram -nowidelut -nosrl -nocarry -nodsp -arch xcup
+synth_xilinx -flatten -nolutram -nowidelut -nosrl -nocarry -nodsp -arch xcup
 
 if { $::env(TECHMAP) != "" } {
     techmap -map $::env(TECHMAP)


### PR DESCRIPTION
Requires https://github.com/SymbiFlow/python-fpga-interchange/pull/112 and https://github.com/YosysHQ/nextpnr/pull/767

Unfortunately I'm running into a hard-to-debug Vivado segfault when running timing analysis, so I've had to disable that for now (as a workaround running timing analysis manually on the DCP in the GUI works fine).