### PR TITLE
Temporary fix for issue #56

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 psutil
 ninja
-rapidyaml
+git+https://github.com/litghost/rapidyaml.git@fixup_python_packaging#egg=rapidyaml
 fasm
 git+https://github.com/SymbiFlow/prjxray.git
 git+https://github.com/SymbiFlow/symbiflow-xc-fasm.git


### PR DESCRIPTION
Change rapidyaml from pypi version to one hosted by litghost

Signed-off-by: Maciej Dudek <mdudek@antmicro.com>