### PR TITLE
tests: add cell to bel mapping in test arch

### DIFF
--- a/devices/chipdb_testarch.cmake
+++ b/devices/chipdb_testarch.cmake
@@ -52,6 +52,18 @@ function(generate_testarch_device_db)
     add_custom_target(testarch-${device}-device DEPENDS ${out_file})
     set_property(TARGET testarch-${device}-device PROPERTY LOCATION ${out_file})
 
+    add_custom_target(testarch-${device}-device-json
+        COMMAND
+            ${PYTHON3} -mfpga_interchange.convert
+                --schema_dir ${INTERCHANGE_SCHEMA_PATH}
+                --schema device
+                --input_format capnp
+                --output_format json
+                ${out_file}
+                ${out_file}.json
+        DEPENDS ${out_file})
+
+
     if (DEFINED output_target)
         set(${output_target} testarch-${device}-device PARENT_SCOPE)
     endif()

--- a/tests/common/libs/cell_sim_test.v
+++ b/tests/common/libs/cell_sim_test.v
@@ -7,11 +7,21 @@
 // SPDX-License-Identifier: ISC
 
 
-module LUT(input A0, A1, A2, A3, output O);
-  parameter [3:0] INIT = 0;
+module LUT1(input I0, output O);
+  parameter [1:0] INIT = 2'h0;
+endmodule
+module LUT2(input I0, I1, output O);
+  parameter [3:0] INIT = 4'h0;
+endmodule
+module LUT3(input I0, I1, I2, output O);
+  parameter [7:0] INIT = 8'h00;
+endmodule
+module LUT4(input I0, I1, I2, I3, output O);
+  parameter [15:0] INIT = 16'h0000;
 endmodule
 module IB(input P, output I); endmodule
 module OB(input O, output P); endmodule
-module DFF(input D, C, R, output Q); endmodule
+module DFFR(input D, C, R, output Q); endmodule
+module DFFS(input D, C, S, output Q); endmodule
 module VCC(output V); endmodule
 module GND(output G); endmodule

--- a/tests/common/libs/remap_test.v
+++ b/tests/common/libs/remap_test.v
@@ -8,7 +8,7 @@
 
 module $_OR_(input A, input B, output Y);
 
-    LUT #(.INIT("16'h000E")) _TECHMAP_REPLACE_ (.A0(A), .A1(B), .A2(1'b0), .A3(1'b0), .O(Y));
+    LUT2 #(.INIT("4'hE")) _TECHMAP_REPLACE_ (.I0(A), .I1(B), .O(Y));
 
 endmodule
 
@@ -27,16 +27,16 @@ module \$lut (A, Y);
   output Y;
   generate
     if (WIDTH == 1) begin
-      LUT #(.INIT(LUT)) _TECHMAP_REPLACE_ (.A0(A[0]), .A1(1'b0), .A2(1'b0), .A3(1'b0), .O(Y));
+      LUT1 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.I0(A[0]), .O(Y));
     end else
     if (WIDTH == 2) begin
-      LUT #(.INIT(LUT)) _TECHMAP_REPLACE_ (.A0(A[0]), .A1(A[1]), .A2(1'b0), .A3(1'b0), .O(Y));
+      LUT2 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.I0(A[0]), .I1(A[1]), .O(Y));
     end else
     if (WIDTH == 3) begin
-      LUT #(.INIT(LUT)) _TECHMAP_REPLACE_ (.A0(A[0]), .A1(A[1]), .A2(A[2]), .A3(1'b0), .O(Y));
+      LUT3 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.I0(A[0]), .I1(A[1]), .I2(A[2]), .O(Y));
     end else
     if (WIDTH == 4) begin
-      LUT #(.INIT(LUT)) _TECHMAP_REPLACE_ (.A0(A[0]), .A1(A[1]), .A2(A[2]), .A3(A[3]), .O(Y));
+      LUT4 #(.INIT(LUT)) _TECHMAP_REPLACE_ (.I0(A[0]), .I1(A[1]), .I2(A[2]), .I3(A[3]), .O(Y));
     end else begin
       wire _TECHMAP_FAIL_ = 1;
     end

--- a/tests/features/lut/lut_testarch.v
+++ b/tests/features/lut/lut_testarch.v
@@ -27,6 +27,6 @@ assign o0_wire = i0_wire | i1_wire;
 assign o1_wire = i2_wire | i3_wire;
 assign ff_wire = i4_wire | i0_wire;
 
-DFF ff_0(.D(ff_wire), .C(1'b1), .R(1'b0), .Q(o2_wire));
+DFFR ff_0(.D(ff_wire), .C(1'b1), .R(1'b0), .Q(o2_wire));
 
 endmodule

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -239,12 +239,12 @@ function(add_generic_test)
                 COMMAND
                     ${VPR}
                     ${device_loc} ${netlist}
-                    --fpga_interchange_device
-                    --fpga_interchange_netlist
+                    --arch_format fpga-interchange
                     --circuit_format fpga-interchange
                     --echo_file on
                     --timing_analysis off
                     --clustering_pin_feasibility_filter off
+                    --constant_net_method route
                 DEPENDS
                     ${arch}-${test_name}-netlist
                     ${device_target}


### PR DESCRIPTION
This PR modifies the primitives library of the test architecture to include different cells that map to the same BEL