### PR TITLE
Feature tests for Ultrascale+ (failing due to no route)

### DIFF
--- a/tests/features/diff_io/CMakeLists.txt
+++ b/tests/features/diff_io/CMakeLists.txt
@@ -1,7 +1,7 @@
 function(diff_io_test name)
     add_generic_test(
         name ${name}
-        board_list basys3
+        board_list basys3 zcu104
         constr_prefix ${name}
         sources ${name}.v
         testbench ${name}_tb.v

--- a/tests/features/diff_io/iobufds-zcu104.xdc
+++ b/tests/features/diff_io/iobufds-zcu104.xdc
@@ -1,0 +1,13 @@
+# ZCU-104 board
+
+# PMOD GPIO
+
+set_property PACKAGE_PIN G8 [get_ports led]
+set_property PACKAGE_PIN H8 [get_ports sw[0]]
+set_property PACKAGE_PIN G7 [get_ports sw[1]]
+
+set_property PACKAGE_PIN H11 [get_ports diff_p]
+set_property PACKAGE_PIN G11 [get_ports diff_n]
+
+set_property IOSTANDARD LVDS [get_ports diff_p]
+set_property IOSTANDARD LVDS [get_ports diff_n]

--- a/tests/features/diff_io/obufds-zcu104.xdc
+++ b/tests/features/diff_io/obufds-zcu104.xdc
@@ -1,0 +1,11 @@
+# ZCU-104 board
+
+# PMOD GPIO
+
+set_property PACKAGE_PIN G8 [get_ports sw]
+
+set_property PACKAGE_PIN H11 [get_ports diff_p]
+set_property PACKAGE_PIN G11 [get_ports diff_n]
+
+set_property IOSTANDARD LVDS [get_ports diff_p]
+set_property IOSTANDARD LVDS [get_ports diff_n]

--- a/tests/features/serdes/CMakeLists.txt
+++ b/tests/features/serdes/CMakeLists.txt
@@ -3,3 +3,11 @@ add_generic_test(
     board_list basys3
     sources serdes.v serdes_test.v
 )
+
+# FIXME: routing error
+add_generic_test(
+    name oserdese3
+    board_list zcu104
+    sources oserdese3.v
+    constr_prefix oserdese3
+)

--- a/tests/features/serdes/oserdese3-zcu104.xdc
+++ b/tests/features/serdes/oserdese3-zcu104.xdc
@@ -1,0 +1,23 @@
+# ZCU-104 board
+
+# Clock
+set_property PACKAGE_PIN H11 [get_ports clk_p]
+set_property PACKAGE_PIN G11 [get_ports clk_n]
+
+set_property IOSTANDARD LVDS [get_ports clk_p]
+set_property IOSTANDARD LVDS [get_ports clk_n]
+
+# PMOD GPIO
+set_property PACKAGE_PIN  H8 [get_ports rst]
+set_property PACKAGE_PIN  G7 [get_ports inputs[0]]
+set_property PACKAGE_PIN  H7 [get_ports inputs[1]]
+set_property PACKAGE_PIN  G6 [get_ports inputs[2]]
+set_property PACKAGE_PIN  H6 [get_ports inputs[3]]
+set_property PACKAGE_PIN  J6 [get_ports inputs[4]]
+set_property PACKAGE_PIN  J7 [get_ports inputs[5]]
+set_property PACKAGE_PIN  J9 [get_ports inputs[6]]
+set_property PACKAGE_PIN  K9 [get_ports inputs[7]]
+set_property PACKAGE_PIN  K8 [get_ports out]
+set_property PACKAGE_PIN  B3 [get_ports t_dat]
+
+set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets clk_IBUF_inst/0]

--- a/tests/features/serdes/oserdese3.v
+++ b/tests/features/serdes/oserdese3.v
@@ -1,0 +1,59 @@
+`timescale 1ns / 1ps
+
+module clkdivider (
+    input wire clk,
+    input wire rst,
+    output wire clk_out
+);
+    parameter DOUBLE_DIVISOR = 1;
+
+    reg counter = 4'b0;
+
+    always @(posedge clk) begin
+        if (rst)
+            counter <= 4'b0;
+        else begin
+            if (counter == DOUBLE_DIVISOR)
+                counter <= 4'b0;
+            else
+                counter <= 4'b1;
+        end
+    end
+
+    assign clk_out = counter < (DOUBLE_DIVISOR / 2);
+endmodule
+
+
+module top (
+    input wire clk_p,
+    input wire clk_n,
+    input wire rst,
+    input wire [7:0] inputs,
+    output wire out,
+    output wire t_dat
+);
+    wire clk;
+    wire clk_div;
+
+    IBUFDS ibuf_ds (.I(clk_p), .IB(clk_n), .O(clk));
+    
+    clkdivider #(.DOUBLE_DIVISOR(4)) clkdiv1 (
+        .clk       (clk),
+        .rst       (rst),
+        .clk_out   (clk_div)
+    );
+
+    OSERDESE3 #(
+        .DATA_WIDTH   (8),
+        .SIM_DEVICE   ("ULTRASCALE_PLUS")
+    ) serializer (
+        .CLK      (clk),
+        .CLKDIV   (clk_div),
+        .RST      (rst),
+        .D        (inputs),
+        .OQ       (out),
+        .T        (1'b1),
+        .T_OUT    (t_dat)
+    );
+    
+endmodule


### PR DESCRIPTION
### This PR adds the following **FAILING** tests for Ultrascale+ family (ZCU104):

**DIFF_IO**:
* IOBUFDS
* OBUFTDS

**SERDES**:
* OSERDESE3

These tests fail on routing stage with _nextpnr_ being unable to find connections between cells.