### PR TITLE
Add tests for Spartan 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        device: ["xc7a35t", "xc7a100t", "xc7a200t", "xc7z010", "xczu7ev", "xc7k480t", "xc7vx980t", "LIFCL-40", "testarch"]
+        device: ["xc7a35t", "xc7a100t", "xc7a200t", "xc7s50", "xc7z010", "xczu7ev", "xc7k480t", "xc7vx980t", "LIFCL-40", "testarch"]
     env:
       LANG: "en_US.UTF-8"
       DEBIAN_FRONTEND: "noninteractive"

--- a/boards/CMakeLists.txt
+++ b/boards/CMakeLists.txt
@@ -17,6 +17,25 @@ add_board(
 )
 
 add_board(
+    name arty_s7_25
+    device_family spartan7
+    device xc7s25
+    arch xc7
+    package csga324
+    speedgrade -1
+    no_fasm
+)
+
+add_board(
+    name arty_s7_50
+    device_family spartan7
+    device xc7s50
+    arch xc7
+    package csga324
+    speedgrade -1
+)
+
+add_board(
     name nexys_video
     device_family artix7
     device xc7a200t

--- a/devices/CMakeLists.txt
+++ b/devices/CMakeLists.txt
@@ -6,6 +6,10 @@ add_subdirectory(xc7a35t)
 add_subdirectory(xc7a100t)
 add_subdirectory(xc7a200t)
 
+# Spartan-7 devices
+add_subdirectory(xc7s25)
+add_subdirectory(xc7s50)
+
 # Zynq-7 devices
 add_subdirectory(xc7z010)
 

--- a/devices/xc7s25/CMakeLists.txt
+++ b/devices/xc7s25/CMakeLists.txt
@@ -1,0 +1,14 @@
+generate_xc7_device_db(
+    device xc7s25
+    part xc7s25csga324-1
+    device_target xc7s25_target
+    family spartan7
+)
+
+generate_chipdb(
+    device xc7s25
+    part xc7s25csga324-1
+    device_target ${xc7s25_target}
+    device_config ${PYTHON_INTERCHANGE_PATH}/test_data/series7_device_config.yaml
+    test_package csga324
+)

--- a/devices/xc7s50/CMakeLists.txt
+++ b/devices/xc7s50/CMakeLists.txt
@@ -1,0 +1,14 @@
+generate_xc7_device_db(
+    device xc7s50
+    part xc7s50csga324-1
+    device_target xc7s50_target
+    family spartan7
+)
+
+generate_chipdb(
+    device xc7s50
+    part xc7s50csga324-1
+    device_target ${xc7s50_target}
+    device_config ${PYTHON_INTERCHANGE_PATH}/test_data/series7_device_config.yaml
+    test_package csga324
+)

--- a/tests/designs/counter/CMakeLists.txt
+++ b/tests/designs/counter/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_generic_test(
     name counter
-    board_list basys3 arty35t arty100t xc7k480t_board xc7vx980t_board lifcl40evn
+    board_list basys3 arty35t arty100t arty_s7_25 arty_s7_50 xc7k480t_board xc7vx980t_board lifcl40evn
     sources counter.v
     testbench counter_tb.v
     techmap ../../common/remap_xc7.v

--- a/tests/designs/counter/arty_s7_25.xdc
+++ b/tests/designs/counter/arty_s7_25.xdc
@@ -1,0 +1,14 @@
+## arty-s7-25 board
+set_property PACKAGE_PIN R2  [get_ports clk]
+set_property PACKAGE_PIN G15 [get_ports rst]
+set_property PACKAGE_PIN E18 [get_ports io_led[4]]
+set_property PACKAGE_PIN F13 [get_ports io_led[5]]
+set_property PACKAGE_PIN E13 [get_ports io_led[6]]
+set_property PACKAGE_PIN H15 [get_ports io_led[7]]
+
+set_property IOSTANDARD LVCMOS33 [get_ports clk]
+set_property IOSTANDARD LVCMOS33 [get_ports rst]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[4]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[5]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[6]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[7]]

--- a/tests/designs/counter/arty_s7_50.xdc
+++ b/tests/designs/counter/arty_s7_50.xdc
@@ -1,0 +1,14 @@
+## arty-s7-50 board
+set_property PACKAGE_PIN R2  [get_ports clk]
+set_property PACKAGE_PIN G15 [get_ports rst]
+set_property PACKAGE_PIN E18 [get_ports io_led[4]]
+set_property PACKAGE_PIN F13 [get_ports io_led[5]]
+set_property PACKAGE_PIN E13 [get_ports io_led[6]]
+set_property PACKAGE_PIN H15 [get_ports io_led[7]]
+
+set_property IOSTANDARD LVCMOS33 [get_ports clk]
+set_property IOSTANDARD LVCMOS33 [get_ports rst]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[4]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[5]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[6]]
+set_property IOSTANDARD LVCMOS33 [get_ports io_led[7]]

--- a/tests/designs/murax/CMakeLists.txt
+++ b/tests/designs/murax/CMakeLists.txt
@@ -18,6 +18,14 @@ add_generic_test(
 
 add_generic_test(
     name murax
+    board_list arty_s7_50
+    top toplevel
+    sources arty_s7_50_toplevel.v
+    absolute_sources ${murax}
+)
+
+add_generic_test(
+    name murax
     board_list lifcl40evn
     top toplevel
     sources lifcl40evn_toplevel.v

--- a/tests/designs/murax/arty_s7_50.xdc
+++ b/tests/designs/murax/arty_s7_50.xdc
@@ -1,0 +1,54 @@
+## arty35t
+
+# Clock
+set_property LOC R2 [get_ports {io_mainClk}]
+set_property IOSTANDARD LVCMOS33 [get_ports {io_mainClk}]
+
+# Serial
+set_property LOC R12 [get_ports {io_uart_txd}]
+set_property IOSTANDARD LVCMOS33 [get_ports {io_uart_txd}]
+
+set_property LOC V12 [get_ports {io_uart_rxd}]
+set_property IOSTANDARD LVCMOS33 [get_ports {io_uart_rxd}]
+
+# sw[7:0] connected to 4 buttons and 4 switches
+set_property LOC H14 [get_ports {sw[0]}]
+set_property LOC H18 [get_ports {sw[1]}]
+set_property LOC G18 [get_ports {sw[2]}]
+set_property LOC M5  [get_ports {sw[3]}]
+set_property LOC G15 [get_ports {sw[4]}]
+set_property LOC K16 [get_ports {sw[5]}]
+set_property LOC J16 [get_ports {sw[6]}]
+set_property LOC H13 [get_ports {sw[7]}]
+
+set_property IOSTANDARD LVCMOS33 [get_ports {sw[0]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {sw[1]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {sw[2]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {sw[3]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {sw[4]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {sw[5]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {sw[6]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {sw[7]}]
+
+# out[9:0] connected to 4 user LEDs and 2 RGB leds (2x3)
+set_property LOC E18 [get_ports {io_led[0]}]
+set_property LOC F13 [get_ports {io_led[1]}]
+set_property LOC E13 [get_ports {io_led[2]}]
+set_property LOC H15 [get_ports {io_led[3]}]
+set_property LOC J15 [get_ports {io_led[4]}]
+set_property LOC G17 [get_ports {io_led[5]}]
+set_property LOC F15 [get_ports {io_led[6]}]
+set_property LOC E15 [get_ports {io_led[7]}]
+set_property LOC F18 [get_ports {io_led[8]}]
+set_property LOC E14 [get_ports {io_led[9]}]
+
+set_property IOSTANDARD LVCMOS33 [get_ports {io_led[0]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {io_led[1]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {io_led[2]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {io_led[3]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {io_led[4]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {io_led[5]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {io_led[6]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {io_led[7]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {io_led[8]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {io_led[9]}]

--- a/tests/designs/murax/arty_s7_50_toplevel.v
+++ b/tests/designs/murax/arty_s7_50_toplevel.v
@@ -1,0 +1,46 @@
+// Copyright (C) 2021  The Symbiflow Authors.
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier: ISC
+
+`timescale 1ns / 1ps
+
+module toplevel(
+    input   io_mainClk,
+    output  io_uart_txd,
+    input   io_uart_rxd,
+    input [7:0] sw,
+    output [9:0] io_led
+  );
+
+  wire [31:0] io_gpioA_read;
+  wire [31:0] io_gpioA_write;
+  wire [31:0] io_gpioA_writeEnable;
+  wire io_mainClk;
+  wire io_jtag_tck;
+  wire io_jtag_tdi;
+  wire io_jtag_tdo;
+  wire io_jtag_tms;
+  wire io_uart_txd;
+  wire io_uart_rxd;
+
+  assign io_led = io_gpioA_write[9: 0];
+  assign io_gpioA_read[7:0] = sw;
+
+  Murax murax (
+    .io_asyncReset(0),
+    .io_mainClk (io_mainClk),
+    .io_jtag_tck(1'b0),
+    .io_jtag_tdi(1'b0),
+    .io_jtag_tms(1'b0),
+    .io_gpioA_read       (io_gpioA_read),
+    .io_gpioA_write      (io_gpioA_write),
+    .io_gpioA_writeEnable(io_gpioA_writeEnable),
+    .io_uart_txd(io_uart_txd),
+    .io_uart_rxd(io_uart_rxd)
+  );
+endmodule
+

--- a/tests/designs/picosoc/CMakeLists.txt
+++ b/tests/designs/picosoc/CMakeLists.txt
@@ -15,6 +15,13 @@ add_generic_test(
 
 add_generic_test(
     name picosoc
+    board_list arty_s7_50
+    top top
+    absolute_sources ${picosoc_dir}/arty_s7_50.v ${picosoc_sources}
+)
+
+add_generic_test(
+    name picosoc
     board_list basys3
     top top
     absolute_sources ${picosoc_dir}/basys3.v ${picosoc_sources}

--- a/tests/designs/picosoc/arty_s7_50.xdc
+++ b/tests/designs/picosoc/arty_s7_50.xdc
@@ -1,0 +1,34 @@
+## arty s7-50
+
+# Clock
+set_property LOC R2 [get_ports {clk}]
+set_property IOSTANDARD LVCMOS33 [get_ports {clk}]
+
+# Serial
+set_property LOC R12 [get_ports {tx}]
+set_property IOSTANDARD LVCMOS33 [get_ports {tx}]
+
+set_property LOC V12 [get_ports {rx}]
+set_property IOSTANDARD LVCMOS33 [get_ports {rx}]
+
+# swiches
+set_property LOC H14 [get_ports {sw[0]}]
+set_property LOC H18 [get_ports {sw[1]}]
+set_property LOC G18 [get_ports {sw[2]}]
+set_property LOC M5  [get_ports {sw[3]}]
+
+set_property IOSTANDARD LVCMOS33 [get_ports {sw[0]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {sw[1]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {sw[2]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {sw[3]}]
+
+# leds
+set_property LOC E18 [get_ports {led[0]}]
+set_property LOC F13 [get_ports {led[1]}]
+set_property LOC E13 [get_ports {led[2]}]
+set_property LOC H15 [get_ports {led[3]}]
+
+set_property IOSTANDARD LVCMOS33 [get_ports {led[0]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {led[1]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {led[2]}]
+set_property IOSTANDARD LVCMOS33 [get_ports {led[3]}]

--- a/third_party/picosoc/arty_s7_50.v
+++ b/third_party/picosoc/arty_s7_50.v
@@ -1,0 +1,89 @@
+/*
+ *  PicoSoC - A simple example SoC using PicoRV32
+ *
+ *  Copyright (C) 2017  Clifford Wolf <clifford@clifford.at>
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+module top (
+    input clk,
+
+    output tx,
+    input  rx,
+
+    input  [3:0] sw,
+    output [3:0] led
+);
+
+  wire clk_bufg;
+  BUFG bufg (
+      .I(clk),
+      .O(clk_bufg)
+  );
+
+  reg [5:0] reset_cnt = 0;
+  wire resetn = &reset_cnt;
+
+  always @(posedge clk_bufg) begin
+    reset_cnt <= reset_cnt + !resetn;
+  end
+
+  wire        iomem_valid;
+  reg         iomem_ready;
+  wire [ 3:0] iomem_wstrb;
+  wire [31:0] iomem_addr;
+  wire [31:0] iomem_wdata;
+  reg  [31:0] iomem_rdata;
+
+  reg  [31:0] gpio;
+
+  assign led = gpio[3:0];
+
+  always @(posedge clk_bufg) begin
+    if (!resetn) begin
+      gpio <= 0;
+    end else begin
+      iomem_ready <= 0;
+      if (iomem_valid && !iomem_ready && iomem_addr[31:24] == 8'h03) begin
+        iomem_ready <= 1;
+        iomem_rdata <= {4{sw, gpio[3:0]}};
+        if (iomem_wstrb[0]) gpio[7:0] <= iomem_wdata[7:0];
+        if (iomem_wstrb[1]) gpio[15:8] <= iomem_wdata[15:8];
+        if (iomem_wstrb[2]) gpio[23:16] <= iomem_wdata[23:16];
+        if (iomem_wstrb[3]) gpio[31:24] <= iomem_wdata[31:24];
+      end
+    end
+  end
+
+  picosoc_noflash soc (
+      .clk   (clk_bufg),
+      .resetn(resetn),
+
+      .ser_tx(tx),
+      .ser_rx(rx),
+
+      .irq_5(1'b0),
+      .irq_6(1'b0),
+      .irq_7(1'b0),
+
+      .iomem_valid(iomem_valid),
+      .iomem_ready(iomem_ready),
+      .iomem_wstrb(iomem_wstrb),
+      .iomem_addr (iomem_addr),
+      .iomem_wdata(iomem_wdata),
+      .iomem_rdata(iomem_rdata)
+  );
+
+endmodule


### PR DESCRIPTION
This adds tests for Arty S7 25/50.
Tests are added for `counter`, `murax` and `picosoc` desgins for `xc7s50` and for `counter` design in case of `xc7s25`.

Tests for `xc7s25` are disabled in CI due to missing part in Vivado which is probably caused by incompatible Vivado version: https://github.com/SymbiFlow/fpga-interchange-tests/runs/5390136359?check_suite_focus=true#step:7:266.